### PR TITLE
Fix: Implement conditional Shopify product upload via API parameter

### DIFF
--- a/backend/api.py
+++ b/backend/api.py
@@ -14,12 +14,12 @@ def generate_listing():
         product_description = data.get("product_description")
         additional_details = data.get("additional_details")
         base_keywords = data.get("base_keywords")
+        upload_flag = data.get("upload", False)  # Default to False if not provided
 
         if not product_description or not additional_details or not base_keywords:
             return jsonify({"error": "Missing required fields"}), 400
 
-        result = run_listing_pipeline(product_description, additional_details, base_keywords)
-
+        result = run_listing_pipeline(product_description, additional_details, base_keywords, upload=upload_flag)
 
         if "error" in result:
             return jsonify(result), 500

--- a/backend/main.py
+++ b/backend/main.py
@@ -10,45 +10,7 @@ from shopify_uploader import upload_product
 
 load_dotenv()
 
-def run_listing_pipeline(product_description, additional_details, upload=False):
-    # Step 1: Task to find SEO keywords
-    keyword_task = Task(
-        description=f"Find trending SEO keywords for Shopify product: {product_description}",
-        expected_output="Comma-separated keywords (max 13)",
-        agent=researcher_agent
-    )
-
-    # Step 2: Task to write Shopify listing
-    listing_task = Task(
-        description=shopify_listing_prompt(product_description, additional_details, "{output_of_task_1}"),
-        expected_output="JSON with title, description, and tags",
-        agent=writer_agent,
-        context=[keyword_task]
-    )
-
-    # Step 3: Run the crew
-    crew = Crew(tasks=[keyword_task, listing_task])
-    results = crew.kickoff()
-
-    # Step 4: Try parsing JSON from string output
-    try:
-        if isinstance(results, str):
-            cleaned = re.sub(r"```json|```", "", results).strip()
-            listing = json.loads(cleaned)
-        elif isinstance(results, dict):
-            listing = results
-        else:
-            raise ValueError("Unexpected result format")
-    except Exception as e:
-        print("❌ Failed to parse AI response:", e)
-        return {"error": "Invalid AI output", "raw": str(results)}
-
-    # Step 5: Upload only if explicitly required
-    if upload:
-        upload_product(
-            listing['title'],
-            listing['description'],
-            listing['tags']
-        )
-
-    return listing
+# The run_listing_pipeline function has been moved to backend/run_listing_pipeline.py
+# and is imported there by api.py.
+# If this main.py is used for CLI or other purposes,
+# it should import run_listing_pipeline from backend.run_listing_pipeline

--- a/backend/run_listing_pipeline.py
+++ b/backend/run_listing_pipeline.py
@@ -9,7 +9,7 @@ from shopify_uploader import upload_product
 
 load_dotenv()
 
-def run_listing_pipeline(product_description, additional_details, base_keywords):
+def run_listing_pipeline(product_description, additional_details, base_keywords, upload=False):
     try:
         keyword_task = Task(
             description=f"Find trending SEO keywords for Shopify product: {product_description}",
@@ -57,7 +57,8 @@ def run_listing_pipeline(product_description, additional_details, base_keywords)
             raise ValueError(f"JSON decode failed: {e}\nRaw output: {cleaned}")
 
         # Upload to Shopify (optional)
-        upload_product(listing['title'], listing['description'], listing['tags'])
+        if upload:
+            upload_product(listing['title'], listing['description'], listing['tags'])
 
         return listing
 

--- a/backend/test_main.py
+++ b/backend/test_main.py
@@ -1,1 +1,8 @@
-from main import run_listing_pipeline; print(run_listing_pipeline('test product', 'test details'))
+from run_listing_pipeline import run_listing_pipeline
+
+# The function now takes base_keywords as a third argument and an optional upload flag.
+# For this test, we'll provide some default base_keywords and test the default upload=False.
+print(run_listing_pipeline('test product', 'test details', 'generic, common'))
+
+# Example of how to test with upload=True (though this might actually attempt an upload if not mocked):
+# print(run_listing_pipeline('test product', 'test details', 'generic, common', upload=True))


### PR DESCRIPTION
- Modified the `/generate-listing` endpoint in `api.py` to accept an optional `upload` boolean parameter (defaults to `False`).
- Updated `run_listing_pipeline.py` to accept an `upload` parameter and only call `upload_product` if this parameter is `True`.
- Removed the redundant `run_listing_pipeline` function from `main.py` to consolidate logic.
- Updated `test_main.py` to align with the new function signature in `run_listing_pipeline.py` and reflect the changes in `main.py`.